### PR TITLE
Do not perform image upsizing

### DIFF
--- a/retinaface/commons/preprocess.py
+++ b/retinaface/commons/preprocess.py
@@ -3,7 +3,7 @@ import cv2
 
 #this function is copied from the following code snippet: https://github.com/StanislasBertrand/RetinaFace-tf2/blob/master/retinaface.py
 def resize_image(img, scales):
-    img_w, img_h = img.shape[0:2]
+    img_h, img_w = img.shape[0:2]
     target_size = scales[0]
     max_size = scales[1]
 
@@ -12,7 +12,7 @@ def resize_image(img, scales):
     else:
         im_size_min, im_size_max = img_w, img_h
 
-    im_scale = target_size / float(im_size_min)
+    im_scale = min(1.0, target_size / float(im_size_min))
 
     if np.round(im_scale * im_size_max) > max_size:
         im_scale = max_size / float(im_size_max)


### PR DESCRIPTION
In a project working with a colleague, we found that when images are smaller than the default size (1024), e.g., `250 x 250`, the runtime was longer than expected because of the upsizing process. However, it appeared to us that the upsizing would not help in detection accuracy. We ended up monkey-patched this proposed change to `resize_image`, and saw significant improvement to runtime, without sacrificing accuracy. We suggest that the upsizing is probably not necessary (or perhaps making it optional).

I also suggest fixing the order: `img_h, img_w`, as the first axis of a NumPy image array gives the image height. Even though this does not affect the result in this function, in the future some contributors may get the wrong idea.

Thanks!