### PR TITLE
Fix logic in assigning `img` variable

### DIFF
--- a/retinaface/RetinaFace.py
+++ b/retinaface/RetinaFace.py
@@ -48,9 +48,6 @@ def detect_faces(img_path, threshold=0.9, model = None):
 	elif isinstance(img_path, np.ndarray): #numpy array
 		img = img_path.copy()
 
-		if not img.any():
-			raise ValueError("Input image array contains all black pixels.")
-
 	else:
 		raise ValueError("Invalid input.")
 

--- a/retinaface/RetinaFace.py
+++ b/retinaface/RetinaFace.py
@@ -49,7 +49,9 @@ def detect_faces(img_path, threshold=0.9, model = None):
 		img = img_path.copy()
 
 	else:
-		raise ValueError("Invalid input.")
+		raise ValueError(
+			"Invalid input. Accept only path to image file or a NumPy array."
+		)
 
 	#---------------------------
 

--- a/retinaface/RetinaFace.py
+++ b/retinaface/RetinaFace.py
@@ -45,8 +45,14 @@ def detect_faces(img_path, threshold=0.9, model = None):
 
 		img = cv2.imread(img_path)
 
-	if (isinstance(img_path, np.ndarray) and img_path.any()): #numpy array
+	elif isinstance(img_path, np.ndarray): #numpy array
 		img = img_path.copy()
+
+		if not img.any():
+			raise ValueError("Input image array contains all black pixels.")
+
+	else:
+		raise ValueError("Invalid input.")
 
 	#---------------------------
 


### PR DESCRIPTION
In the original version, when `img_path` is an array representing a black image (with all-zero pixel values), `img_path.any()` will give `False` and hence the variable `img` is not being declared in both `if` clauses, causing an error raised from a few lines below:
```
UnboundLocalError: local variable \'img\' referenced before assignment
```

The suggested fix does the following:
- Separate the concerns for checking whether `img_path` is a NumPy array, and checking whether it is an all-zero array.
- Add an extra `else` clause to raise if `img_path` is neither a path to an image file nor a NumPy array.

Please feel free to change the raise messages.
Thanks in advance for your consideration!

**EDIT:**
I have tested that, there is no problem for the net to handle all-zero array, so I actually would suggest removing the `img.any()` check. From a user point of view, it feels strange to raise a black image, I think just letting the net say it contains no faces is fine. :slightly_smiling_face: 