### PR TITLE
Unify the usage of 4 spaces for indentation over all .py files

### DIFF
--- a/retinaface/RetinaFace.py
+++ b/retinaface/RetinaFace.py
@@ -19,196 +19,196 @@ import tensorflow as tf
 tf_version = int(tf.__version__.split(".")[0])
 
 if tf_version == 2:
-	import logging
-	tf.get_logger().setLevel(logging.ERROR)
+    import logging
+    tf.get_logger().setLevel(logging.ERROR)
 
 #---------------------------
 
 def build_model():
-	
-	global model #singleton design pattern
-	
-	if not "model" in globals():
-		
-		model = tf.function(
-			retinaface_model.build_model(),
-			input_signature=(tf.TensorSpec(shape=[None, None, None, 3], dtype=np.float32),)
-		)
+    
+    global model #singleton design pattern
+    
+    if not "model" in globals():
+        
+        model = tf.function(
+            retinaface_model.build_model(),
+            input_signature=(tf.TensorSpec(shape=[None, None, None, 3], dtype=np.float32),)
+        )
 
-	return model
+    return model
 
 def get_image(img_path):
-	if (type(img_path) == str and img_path != None):  # exact image path
+    if (type(img_path) == str and img_path != None):  # exact image path
 
-		if os.path.isfile(img_path) != True:
-			raise ValueError("Confirm that ", img_path, " exists")
+        if os.path.isfile(img_path) != True:
+            raise ValueError("Confirm that ", img_path, " exists")
 
-		return cv2.imread(img_path)
+        return cv2.imread(img_path)
 
-	elif (isinstance(img_path, np.ndarray) and img_path.any()):  # numpy array
-		return img_path.copy()
+    elif (isinstance(img_path, np.ndarray) and img_path.any()):  # numpy array
+        return img_path.copy()
 
-	else:
-		raise ValueError(
-			"Invalid input. Accept only path to image file or a NumPy array."
-		)
+    else:
+        raise ValueError(
+            "Invalid input. Accept only path to image file or a NumPy array."
+        )
 
 def detect_faces(img_path, threshold=0.9, model = None):
-	"""
-	TODO: add function doc here
-	"""
+    """
+    TODO: add function doc here
+    """
 
-	img = get_image(img_path)
+    img = get_image(img_path)
 
-	#---------------------------
+    #---------------------------
 
-	if model is None:
-		model = build_model()
+    if model is None:
+        model = build_model()
 
-	#---------------------------
+    #---------------------------
 
-	nms_threshold = 0.4; decay4=0.5
+    nms_threshold = 0.4; decay4=0.5
 
-	_feat_stride_fpn = [32, 16, 8]
+    _feat_stride_fpn = [32, 16, 8]
 
-	_anchors_fpn = {
-		'stride32': np.array([[-248., -248.,  263.,  263.], [-120., -120.,  135.,  135.]], dtype=np.float32),
-		'stride16': np.array([[-56., -56.,  71.,  71.], [-24., -24.,  39.,  39.]], dtype=np.float32),
-		'stride8': np.array([[-8., -8., 23., 23.], [ 0.,  0., 15., 15.]], dtype=np.float32)
-	}
+    _anchors_fpn = {
+        'stride32': np.array([[-248., -248.,  263.,  263.], [-120., -120.,  135.,  135.]], dtype=np.float32),
+        'stride16': np.array([[-56., -56.,  71.,  71.], [-24., -24.,  39.,  39.]], dtype=np.float32),
+        'stride8': np.array([[-8., -8., 23., 23.], [ 0.,  0., 15., 15.]], dtype=np.float32)
+    }
 
-	_num_anchors = {'stride32': 2, 'stride16': 2, 'stride8': 2}
+    _num_anchors = {'stride32': 2, 'stride16': 2, 'stride8': 2}
 
-	#---------------------------
+    #---------------------------
 
-	proposals_list = []
-	scores_list = []
-	landmarks_list = []
-	im_tensor, im_info, im_scale = preprocess.preprocess_image(img)
-	net_out = model(im_tensor)
-	net_out = [elt.numpy() for elt in net_out]
-	sym_idx = 0
+    proposals_list = []
+    scores_list = []
+    landmarks_list = []
+    im_tensor, im_info, im_scale = preprocess.preprocess_image(img)
+    net_out = model(im_tensor)
+    net_out = [elt.numpy() for elt in net_out]
+    sym_idx = 0
 
-	for _idx, s in enumerate(_feat_stride_fpn):
-		_key = 'stride%s'%s
-		scores = net_out[sym_idx]
-		scores = scores[:, :, :, _num_anchors['stride%s'%s]:]
+    for _idx, s in enumerate(_feat_stride_fpn):
+        _key = 'stride%s'%s
+        scores = net_out[sym_idx]
+        scores = scores[:, :, :, _num_anchors['stride%s'%s]:]
 
-		bbox_deltas = net_out[sym_idx + 1]
-		height, width = bbox_deltas.shape[1], bbox_deltas.shape[2]
+        bbox_deltas = net_out[sym_idx + 1]
+        height, width = bbox_deltas.shape[1], bbox_deltas.shape[2]
 
-		A = _num_anchors['stride%s'%s]
-		K = height * width
-		anchors_fpn = _anchors_fpn['stride%s'%s]
-		anchors = postprocess.anchors_plane(height, width, s, anchors_fpn)
-		anchors = anchors.reshape((K * A, 4))
-		scores = scores.reshape((-1, 1))
+        A = _num_anchors['stride%s'%s]
+        K = height * width
+        anchors_fpn = _anchors_fpn['stride%s'%s]
+        anchors = postprocess.anchors_plane(height, width, s, anchors_fpn)
+        anchors = anchors.reshape((K * A, 4))
+        scores = scores.reshape((-1, 1))
 
-		bbox_stds = [1.0, 1.0, 1.0, 1.0]
-		bbox_deltas = bbox_deltas
-		bbox_pred_len = bbox_deltas.shape[3]//A
-		bbox_deltas = bbox_deltas.reshape((-1, bbox_pred_len))
-		bbox_deltas[:, 0::4] = bbox_deltas[:,0::4] * bbox_stds[0]
-		bbox_deltas[:, 1::4] = bbox_deltas[:,1::4] * bbox_stds[1]
-		bbox_deltas[:, 2::4] = bbox_deltas[:,2::4] * bbox_stds[2]
-		bbox_deltas[:, 3::4] = bbox_deltas[:,3::4] * bbox_stds[3]
-		proposals = postprocess.bbox_pred(anchors, bbox_deltas)
+        bbox_stds = [1.0, 1.0, 1.0, 1.0]
+        bbox_deltas = bbox_deltas
+        bbox_pred_len = bbox_deltas.shape[3]//A
+        bbox_deltas = bbox_deltas.reshape((-1, bbox_pred_len))
+        bbox_deltas[:, 0::4] = bbox_deltas[:,0::4] * bbox_stds[0]
+        bbox_deltas[:, 1::4] = bbox_deltas[:,1::4] * bbox_stds[1]
+        bbox_deltas[:, 2::4] = bbox_deltas[:,2::4] * bbox_stds[2]
+        bbox_deltas[:, 3::4] = bbox_deltas[:,3::4] * bbox_stds[3]
+        proposals = postprocess.bbox_pred(anchors, bbox_deltas)
 
-		proposals = postprocess.clip_boxes(proposals, im_info[:2])
+        proposals = postprocess.clip_boxes(proposals, im_info[:2])
 
-		if s==4 and decay4<1.0:
-			scores *= decay4
+        if s==4 and decay4<1.0:
+            scores *= decay4
 
-		scores_ravel = scores.ravel()
-		order = np.where(scores_ravel>=threshold)[0]
-		proposals = proposals[order, :]
-		scores = scores[order]
+        scores_ravel = scores.ravel()
+        order = np.where(scores_ravel>=threshold)[0]
+        proposals = proposals[order, :]
+        scores = scores[order]
 
-		proposals[:, 0:4] /= im_scale
-		proposals_list.append(proposals)
-		scores_list.append(scores)
+        proposals[:, 0:4] /= im_scale
+        proposals_list.append(proposals)
+        scores_list.append(scores)
 
-		landmark_deltas = net_out[sym_idx + 2]
-		landmark_pred_len = landmark_deltas.shape[3]//A
-		landmark_deltas = landmark_deltas.reshape((-1, 5, landmark_pred_len//5))
-		landmarks = postprocess.landmark_pred(anchors, landmark_deltas)
-		landmarks = landmarks[order, :]
+        landmark_deltas = net_out[sym_idx + 2]
+        landmark_pred_len = landmark_deltas.shape[3]//A
+        landmark_deltas = landmark_deltas.reshape((-1, 5, landmark_pred_len//5))
+        landmarks = postprocess.landmark_pred(anchors, landmark_deltas)
+        landmarks = landmarks[order, :]
 
-		landmarks[:, :, 0:2] /= im_scale
-		landmarks_list.append(landmarks)
-		sym_idx += 3
+        landmarks[:, :, 0:2] /= im_scale
+        landmarks_list.append(landmarks)
+        sym_idx += 3
 
-	proposals = np.vstack(proposals_list)
-	if proposals.shape[0]==0:
-		landmarks = np.zeros( (0,5,2) )
-		return np.zeros( (0,5) ), landmarks
-	scores = np.vstack(scores_list)
-	scores_ravel = scores.ravel()
-	order = scores_ravel.argsort()[::-1]
+    proposals = np.vstack(proposals_list)
+    if proposals.shape[0]==0:
+        landmarks = np.zeros( (0,5,2) )
+        return np.zeros( (0,5) ), landmarks
+    scores = np.vstack(scores_list)
+    scores_ravel = scores.ravel()
+    order = scores_ravel.argsort()[::-1]
 
-	proposals = proposals[order, :]
-	scores = scores[order]
-	landmarks = np.vstack(landmarks_list)
-	landmarks = landmarks[order].astype(np.float32, copy=False)
+    proposals = proposals[order, :]
+    scores = scores[order]
+    landmarks = np.vstack(landmarks_list)
+    landmarks = landmarks[order].astype(np.float32, copy=False)
 
-	pre_det = np.hstack((proposals[:,0:4], scores)).astype(np.float32, copy=False)
+    pre_det = np.hstack((proposals[:,0:4], scores)).astype(np.float32, copy=False)
 
-	#nms = cpu_nms_wrapper(nms_threshold)
-	#keep = nms(pre_det)
-	keep = postprocess.cpu_nms(pre_det, nms_threshold)
+    #nms = cpu_nms_wrapper(nms_threshold)
+    #keep = nms(pre_det)
+    keep = postprocess.cpu_nms(pre_det, nms_threshold)
 
-	det = np.hstack( (pre_det, proposals[:,4:]) )
-	det = det[keep, :]
-	landmarks = landmarks[keep]
+    det = np.hstack( (pre_det, proposals[:,4:]) )
+    det = det[keep, :]
+    landmarks = landmarks[keep]
 
-	resp = {}
-	for idx, face in enumerate(det):
+    resp = {}
+    for idx, face in enumerate(det):
 
-		label = 'face_'+str(idx+1)
-		resp[label] = {}
-		resp[label]["score"] = face[4]
+        label = 'face_'+str(idx+1)
+        resp[label] = {}
+        resp[label]["score"] = face[4]
 
-		resp[label]["facial_area"] = list(face[0:4].astype(int))
+        resp[label]["facial_area"] = list(face[0:4].astype(int))
 
-		resp[label]["landmarks"] = {}
-		resp[label]["landmarks"]["right_eye"] = list(landmarks[idx][0])
-		resp[label]["landmarks"]["left_eye"] = list(landmarks[idx][1])
-		resp[label]["landmarks"]["nose"] = list(landmarks[idx][2])
-		resp[label]["landmarks"]["mouth_right"] = list(landmarks[idx][3])
-		resp[label]["landmarks"]["mouth_left"] = list(landmarks[idx][4])
+        resp[label]["landmarks"] = {}
+        resp[label]["landmarks"]["right_eye"] = list(landmarks[idx][0])
+        resp[label]["landmarks"]["left_eye"] = list(landmarks[idx][1])
+        resp[label]["landmarks"]["nose"] = list(landmarks[idx][2])
+        resp[label]["landmarks"]["mouth_right"] = list(landmarks[idx][3])
+        resp[label]["landmarks"]["mouth_left"] = list(landmarks[idx][4])
 
-	return resp
+    return resp
 
 def extract_faces(img_path, threshold=0.9, model = None, align = True):
 
-	resp = []
+    resp = []
 
-	#---------------------------
+    #---------------------------
 
-	img = get_image(img_path)
+    img = get_image(img_path)
 
-	#---------------------------
+    #---------------------------
 
-	obj = detect_faces(img_path = img, threshold = threshold, model = model)
+    obj = detect_faces(img_path = img, threshold = threshold, model = model)
 
-	if type(obj) == dict:
-		for key in obj:
-			identity = obj[key]
+    if type(obj) == dict:
+        for key in obj:
+            identity = obj[key]
 
-			facial_area = identity["facial_area"]
-			facial_img = img[facial_area[1]: facial_area[3], facial_area[0]: facial_area[2]]
+            facial_area = identity["facial_area"]
+            facial_img = img[facial_area[1]: facial_area[3], facial_area[0]: facial_area[2]]
 
-			if align == True:
-				landmarks = identity["landmarks"]
-				left_eye = landmarks["left_eye"]
-				right_eye = landmarks["right_eye"]
-				nose = landmarks["nose"]
-				mouth_right = landmarks["mouth_right"]
-				mouth_left = landmarks["mouth_left"]
+            if align == True:
+                landmarks = identity["landmarks"]
+                left_eye = landmarks["left_eye"]
+                right_eye = landmarks["right_eye"]
+                nose = landmarks["nose"]
+                mouth_right = landmarks["mouth_right"]
+                mouth_left = landmarks["mouth_left"]
 
-				facial_img = postprocess.alignment_procedure(facial_img, right_eye, left_eye, nose)
+                facial_img = postprocess.alignment_procedure(facial_img, right_eye, left_eye, nose)
 
-			resp.append(facial_img[:, :, ::-1])
-	#elif type(obj) == tuple:
+            resp.append(facial_img[:, :, ::-1])
+    #elif type(obj) == tuple:
 
-	return resp
+    return resp

--- a/retinaface/commons/postprocess.py
+++ b/retinaface/commons/postprocess.py
@@ -3,176 +3,176 @@ from PIL import Image
 import math
 
 def findEuclideanDistance(source_representation, test_representation):
-	euclidean_distance = source_representation - test_representation
-	euclidean_distance = np.sum(np.multiply(euclidean_distance, euclidean_distance))
-	euclidean_distance = np.sqrt(euclidean_distance)
-	return euclidean_distance
+    euclidean_distance = source_representation - test_representation
+    euclidean_distance = np.sum(np.multiply(euclidean_distance, euclidean_distance))
+    euclidean_distance = np.sqrt(euclidean_distance)
+    return euclidean_distance
 
 #this function copied from the deepface repository: https://github.com/serengil/deepface/blob/master/deepface/commons/functions.py
 def alignment_procedure(img, left_eye, right_eye, nose):
 
-	#this function aligns given face in img based on left and right eye coordinates
+    #this function aligns given face in img based on left and right eye coordinates
 
-	left_eye_x, left_eye_y = left_eye
-	right_eye_x, right_eye_y = right_eye
+    left_eye_x, left_eye_y = left_eye
+    right_eye_x, right_eye_y = right_eye
 
-	#-----------------------
-	upside_down = False
-	if nose[1] < left_eye[1] or nose[1] < right_eye[1]:
-		upside_down = True
+    #-----------------------
+    upside_down = False
+    if nose[1] < left_eye[1] or nose[1] < right_eye[1]:
+        upside_down = True
 
-	#-----------------------
-	#find rotation direction
+    #-----------------------
+    #find rotation direction
 
-	if left_eye_y > right_eye_y:
-		point_3rd = (right_eye_x, left_eye_y)
-		direction = -1 #rotate same direction to clock
-	else:
-		point_3rd = (left_eye_x, right_eye_y)
-		direction = 1 #rotate inverse direction of clock
+    if left_eye_y > right_eye_y:
+        point_3rd = (right_eye_x, left_eye_y)
+        direction = -1 #rotate same direction to clock
+    else:
+        point_3rd = (left_eye_x, right_eye_y)
+        direction = 1 #rotate inverse direction of clock
 
-	#-----------------------
-	#find length of triangle edges
+    #-----------------------
+    #find length of triangle edges
 
-	a = findEuclideanDistance(np.array(left_eye), np.array(point_3rd))
-	b = findEuclideanDistance(np.array(right_eye), np.array(point_3rd))
-	c = findEuclideanDistance(np.array(right_eye), np.array(left_eye))
+    a = findEuclideanDistance(np.array(left_eye), np.array(point_3rd))
+    b = findEuclideanDistance(np.array(right_eye), np.array(point_3rd))
+    c = findEuclideanDistance(np.array(right_eye), np.array(left_eye))
 
-	#-----------------------
+    #-----------------------
 
-	#apply cosine rule
+    #apply cosine rule
 
-	if b != 0 and c != 0: #this multiplication causes division by zero in cos_a calculation
+    if b != 0 and c != 0: #this multiplication causes division by zero in cos_a calculation
 
-		cos_a = (b*b + c*c - a*a)/(2*b*c)
-		
-		#PR15: While mathematically cos_a must be within the closed range [-1.0, 1.0], floating point errors would produce cases violating this
-		#In fact, we did come across a case where cos_a took the value 1.0000000169176173, which lead to a NaN from the following np.arccos step
-		cos_a = min(1.0, max(-1.0, cos_a))
-		
-		
-		angle = np.arccos(cos_a) #angle in radian
-		angle = (angle * 180) / math.pi #radian to degree
+        cos_a = (b*b + c*c - a*a)/(2*b*c)
+        
+        #PR15: While mathematically cos_a must be within the closed range [-1.0, 1.0], floating point errors would produce cases violating this
+        #In fact, we did come across a case where cos_a took the value 1.0000000169176173, which lead to a NaN from the following np.arccos step
+        cos_a = min(1.0, max(-1.0, cos_a))
+        
+        
+        angle = np.arccos(cos_a) #angle in radian
+        angle = (angle * 180) / math.pi #radian to degree
 
-		#-----------------------
-		#rotate base image
+        #-----------------------
+        #rotate base image
 
-		if direction == -1:
-			angle = 90 - angle
+        if direction == -1:
+            angle = 90 - angle
 
-		if upside_down == True:
-			angle = angle + 90
+        if upside_down == True:
+            angle = angle + 90
 
-		img = Image.fromarray(img)
-		img = np.array(img.rotate(direction * angle))
+        img = Image.fromarray(img)
+        img = np.array(img.rotate(direction * angle))
 
-	#-----------------------
+    #-----------------------
 
-	return img #return img anyway
+    return img #return img anyway
 
 #this function is copied from the following code snippet: https://github.com/StanislasBertrand/RetinaFace-tf2/blob/master/retinaface.py
 def bbox_pred(boxes, box_deltas):
-	if boxes.shape[0] == 0:
-		return np.zeros((0, box_deltas.shape[1]))
+    if boxes.shape[0] == 0:
+        return np.zeros((0, box_deltas.shape[1]))
 
-	boxes = boxes.astype(np.float, copy=False)
-	widths = boxes[:, 2] - boxes[:, 0] + 1.0
-	heights = boxes[:, 3] - boxes[:, 1] + 1.0
-	ctr_x = boxes[:, 0] + 0.5 * (widths - 1.0)
-	ctr_y = boxes[:, 1] + 0.5 * (heights - 1.0)
+    boxes = boxes.astype(np.float, copy=False)
+    widths = boxes[:, 2] - boxes[:, 0] + 1.0
+    heights = boxes[:, 3] - boxes[:, 1] + 1.0
+    ctr_x = boxes[:, 0] + 0.5 * (widths - 1.0)
+    ctr_y = boxes[:, 1] + 0.5 * (heights - 1.0)
 
-	dx = box_deltas[:, 0:1]
-	dy = box_deltas[:, 1:2]
-	dw = box_deltas[:, 2:3]
-	dh = box_deltas[:, 3:4]
+    dx = box_deltas[:, 0:1]
+    dy = box_deltas[:, 1:2]
+    dw = box_deltas[:, 2:3]
+    dh = box_deltas[:, 3:4]
 
-	pred_ctr_x = dx * widths[:, np.newaxis] + ctr_x[:, np.newaxis]
-	pred_ctr_y = dy * heights[:, np.newaxis] + ctr_y[:, np.newaxis]
-	pred_w = np.exp(dw) * widths[:, np.newaxis]
-	pred_h = np.exp(dh) * heights[:, np.newaxis]
+    pred_ctr_x = dx * widths[:, np.newaxis] + ctr_x[:, np.newaxis]
+    pred_ctr_y = dy * heights[:, np.newaxis] + ctr_y[:, np.newaxis]
+    pred_w = np.exp(dw) * widths[:, np.newaxis]
+    pred_h = np.exp(dh) * heights[:, np.newaxis]
 
-	pred_boxes = np.zeros(box_deltas.shape)
-	# x1
-	pred_boxes[:, 0:1] = pred_ctr_x - 0.5 * (pred_w - 1.0)
-	# y1
-	pred_boxes[:, 1:2] = pred_ctr_y - 0.5 * (pred_h - 1.0)
-	# x2
-	pred_boxes[:, 2:3] = pred_ctr_x + 0.5 * (pred_w - 1.0)
-	# y2
-	pred_boxes[:, 3:4] = pred_ctr_y + 0.5 * (pred_h - 1.0)
+    pred_boxes = np.zeros(box_deltas.shape)
+    # x1
+    pred_boxes[:, 0:1] = pred_ctr_x - 0.5 * (pred_w - 1.0)
+    # y1
+    pred_boxes[:, 1:2] = pred_ctr_y - 0.5 * (pred_h - 1.0)
+    # x2
+    pred_boxes[:, 2:3] = pred_ctr_x + 0.5 * (pred_w - 1.0)
+    # y2
+    pred_boxes[:, 3:4] = pred_ctr_y + 0.5 * (pred_h - 1.0)
 
-	if box_deltas.shape[1]>4:
-		pred_boxes[:,4:] = box_deltas[:,4:]
+    if box_deltas.shape[1]>4:
+        pred_boxes[:,4:] = box_deltas[:,4:]
 
-	return pred_boxes
+    return pred_boxes
 
 # This function copied from the following code snippet: https://github.com/StanislasBertrand/RetinaFace-tf2/blob/master/retinaface.py
 def landmark_pred(boxes, landmark_deltas):
-	if boxes.shape[0] == 0:
-	  return np.zeros((0, landmark_deltas.shape[1]))
-	boxes = boxes.astype(np.float, copy=False)
-	widths = boxes[:, 2] - boxes[:, 0] + 1.0
-	heights = boxes[:, 3] - boxes[:, 1] + 1.0
-	ctr_x = boxes[:, 0] + 0.5 * (widths - 1.0)
-	ctr_y = boxes[:, 1] + 0.5 * (heights - 1.0)
-	pred = landmark_deltas.copy()
-	for i in range(5):
-		pred[:,i,0] = landmark_deltas[:,i,0]*widths + ctr_x
-		pred[:,i,1] = landmark_deltas[:,i,1]*heights + ctr_y
-	return pred
+    if boxes.shape[0] == 0:
+      return np.zeros((0, landmark_deltas.shape[1]))
+    boxes = boxes.astype(np.float, copy=False)
+    widths = boxes[:, 2] - boxes[:, 0] + 1.0
+    heights = boxes[:, 3] - boxes[:, 1] + 1.0
+    ctr_x = boxes[:, 0] + 0.5 * (widths - 1.0)
+    ctr_y = boxes[:, 1] + 0.5 * (heights - 1.0)
+    pred = landmark_deltas.copy()
+    for i in range(5):
+        pred[:,i,0] = landmark_deltas[:,i,0]*widths + ctr_x
+        pred[:,i,1] = landmark_deltas[:,i,1]*heights + ctr_y
+    return pred
 
 # This function copied from rcnn module of retinaface-tf2 project: https://github.com/StanislasBertrand/RetinaFace-tf2/blob/master/rcnn/processing/bbox_transform.py
 def clip_boxes(boxes, im_shape):
-	# x1 >= 0
-	boxes[:, 0::4] = np.maximum(np.minimum(boxes[:, 0::4], im_shape[1] - 1), 0)
-	# y1 >= 0
-	boxes[:, 1::4] = np.maximum(np.minimum(boxes[:, 1::4], im_shape[0] - 1), 0)
-	# x2 < im_shape[1]
-	boxes[:, 2::4] = np.maximum(np.minimum(boxes[:, 2::4], im_shape[1] - 1), 0)
-	# y2 < im_shape[0]
-	boxes[:, 3::4] = np.maximum(np.minimum(boxes[:, 3::4], im_shape[0] - 1), 0)
-	return boxes
+    # x1 >= 0
+    boxes[:, 0::4] = np.maximum(np.minimum(boxes[:, 0::4], im_shape[1] - 1), 0)
+    # y1 >= 0
+    boxes[:, 1::4] = np.maximum(np.minimum(boxes[:, 1::4], im_shape[0] - 1), 0)
+    # x2 < im_shape[1]
+    boxes[:, 2::4] = np.maximum(np.minimum(boxes[:, 2::4], im_shape[1] - 1), 0)
+    # y2 < im_shape[0]
+    boxes[:, 3::4] = np.maximum(np.minimum(boxes[:, 3::4], im_shape[0] - 1), 0)
+    return boxes
 
 #this function is mainly based on the following code snippet: https://github.com/StanislasBertrand/RetinaFace-tf2/blob/master/rcnn/cython/anchors.pyx
 def anchors_plane(height, width, stride, base_anchors):
-	A = base_anchors.shape[0]
-	c_0_2 = np.tile(np.arange(0, width)[np.newaxis, :, np.newaxis, np.newaxis], (height, 1, A, 1))
-	c_1_3 = np.tile(np.arange(0, height)[:, np.newaxis, np.newaxis, np.newaxis], (1, width, A, 1))
-	all_anchors = np.concatenate([c_0_2, c_1_3, c_0_2, c_1_3], axis=-1) * stride + np.tile(base_anchors[np.newaxis, np.newaxis, :, :], (height, width, 1, 1))
-	return all_anchors
+    A = base_anchors.shape[0]
+    c_0_2 = np.tile(np.arange(0, width)[np.newaxis, :, np.newaxis, np.newaxis], (height, 1, A, 1))
+    c_1_3 = np.tile(np.arange(0, height)[:, np.newaxis, np.newaxis, np.newaxis], (1, width, A, 1))
+    all_anchors = np.concatenate([c_0_2, c_1_3, c_0_2, c_1_3], axis=-1) * stride + np.tile(base_anchors[np.newaxis, np.newaxis, :, :], (height, width, 1, 1))
+    return all_anchors
 
 #this function is mainly based on the following code snippet: https://github.com/StanislasBertrand/RetinaFace-tf2/blob/master/rcnn/cython/cpu_nms.pyx
 #Fast R-CNN by Ross Girshick
 def cpu_nms(dets, threshold):
-	x1 = dets[:, 0]
-	y1 = dets[:, 1]
-	x2 = dets[:, 2]
-	y2 = dets[:, 3]
-	scores = dets[:, 4]
+    x1 = dets[:, 0]
+    y1 = dets[:, 1]
+    x2 = dets[:, 2]
+    y2 = dets[:, 3]
+    scores = dets[:, 4]
 
-	areas = (x2 - x1 + 1) * (y2 - y1 + 1)
-	order = scores.argsort()[::-1]
+    areas = (x2 - x1 + 1) * (y2 - y1 + 1)
+    order = scores.argsort()[::-1]
 
-	ndets = dets.shape[0]
-	suppressed = np.zeros((ndets), dtype=np.int)
+    ndets = dets.shape[0]
+    suppressed = np.zeros((ndets), dtype=np.int)
 
-	keep = []
-	for _i in range(ndets):
-		i = order[_i]
-		if suppressed[i] == 1:
-			continue
-		keep.append(i)
-		ix1 = x1[i]; iy1 = y1[i]; ix2 = x2[i]; iy2 = y2[i]
-		iarea = areas[i]
-		for _j in range(_i + 1, ndets):
-			j = order[_j]
-			if suppressed[j] == 1:
-				continue
-			xx1 = max(ix1, x1[j]); yy1 = max(iy1, y1[j]); xx2 = min(ix2, x2[j]); yy2 = min(iy2, y2[j])
-			w = max(0.0, xx2 - xx1 + 1); h = max(0.0, yy2 - yy1 + 1)
-			inter = w * h
-			ovr = inter / (iarea + areas[j] - inter)
-			if ovr >= threshold:
-				suppressed[j] = 1
+    keep = []
+    for _i in range(ndets):
+        i = order[_i]
+        if suppressed[i] == 1:
+            continue
+        keep.append(i)
+        ix1 = x1[i]; iy1 = y1[i]; ix2 = x2[i]; iy2 = y2[i]
+        iarea = areas[i]
+        for _j in range(_i + 1, ndets):
+            j = order[_j]
+            if suppressed[j] == 1:
+                continue
+            xx1 = max(ix1, x1[j]); yy1 = max(iy1, y1[j]); xx2 = min(ix2, x2[j]); yy2 = min(iy2, y2[j])
+            w = max(0.0, xx2 - xx1 + 1); h = max(0.0, yy2 - yy1 + 1)
+            inter = w * h
+            ovr = inter / (iarea + areas[j] - inter)
+            if ovr >= threshold:
+                suppressed[j] = 1
 
-	return keep
+    return keep


### PR DESCRIPTION
Most `.py` files in this repository use spaces (4) for indentation:
- `retinaface/model/retinaface_model.py`
- `retinaface/commons/preprocess.py`
- `tests/unit-tests.py`
- `setup.py`

However, the following two files currently use tabs instead:
- `retinaface/commons/postprocess.py`
- `retinaface/RetinaFace.py`

This pull request switches those two files to spaces too. (This also matches nicely [the recommendation in PEP 8](https://www.python.org/dev/peps/pep-0008/#tabs-or-spaces). :slightly_smiling_face:)