### PR TITLE
Improve and unify image checks and allow black images as input

### DIFF
--- a/retinaface/RetinaFace.py
+++ b/retinaface/RetinaFace.py
@@ -38,20 +38,22 @@ def build_model():
     return model
 
 def get_image(img_path):
-    if (type(img_path) == str and img_path != None):  # exact image path
+    if type(img_path) == str:  # Load from file path
+        if not os.path.isfile(img_path):
+            raise ValueError("Input image file path (", img_path, ") does not exist.")
+        img = cv2.imread(img_path)
 
-        if os.path.isfile(img_path) != True:
-            raise ValueError("Confirm that ", img_path, " exists")
-
-        return cv2.imread(img_path)
-
-    elif (isinstance(img_path, np.ndarray) and img_path.any()):  # numpy array
-        return img_path.copy()
+    elif isinstance(img_path, np.ndarray):  # Use given NumPy array
+        img = img_path.copy()
 
     else:
-        raise ValueError(
-            "Invalid input. Accept only path to image file or a NumPy array."
-        )
+        raise ValueError("Invalid image input. Only file paths or a NumPy array accepted.")
+
+    # Validate image shape
+    if len(img.shape) != 3 or np.prod(img.shape) == 0:
+        raise ValueError("Input image needs to have 3 channels at must not be empty.")
+
+    return img
 
 def detect_faces(img_path, threshold=0.9, model = None):
     """


### PR DESCRIPTION
(This is kind of a follow-up to [PR17](https://github.com/serengil/retinaface/pull/17).)

Currently, the library behaves as follows:

```python3
import urllib.request
import cv2

from retinaface import RetinaFace

urllib.request.urlretrieve("https://i.imgur.com/Xr132lX.png", "blue_ish_image.png")
urllib.request.urlretrieve("https://i.imgur.com/Tk6xrDR.png", "white_image.png")
urllib.request.urlretrieve("https://i.imgur.com/jmIMMHT.png", "dark_gray_image.png")
urllib.request.urlretrieve("https://i.imgur.com/pobfmE0.png", "black_image.png")

RetinaFace.detect_faces("blue_ish_image.png")  # OK
RetinaFace.detect_faces("white_image.png")  # OK
RetinaFace.detect_faces("dark_gray_image.png")  # OK
RetinaFace.detect_faces("black_image.png")  # OK

RetinaFace.detect_faces(cv2.imread("blue_ish_image.png"))  # OK
RetinaFace.detect_faces(cv2.imread("white_image.png"))  # OK
RetinaFace.detect_faces(cv2.imread("dark_gray_image.png"))  # OK
RetinaFace.detect_faces(cv2.imread("black_image.png"))  # ValueError: Invalid input. Accept only path to image file or a NumPy array.
```

To me, as a user, the last line throwing an exception instead of returning a normal ("no face found") result, is somewhat surprising, because:
- Providing a pre-loaded image results in different behavior compared to letting the library load the same image.
- Providing a pre-loaded black image behaves differently compared to providing a pre-loaded gray (or whatever) image.

This Pull request fixed this, by no longer treating black images differently from other images, and by unifying the image checks independently of how the image was loaded (user code or library code).

The `img_path.any()` check was kept after [PR16](https://github.com/serengil/retinaface/pull/16), I guess because it provides a safety net for blocking empty images, i.e., images without any pixels, since [`numpy.any()` works as follows](https://numpy.org/doc/stable/reference/generated/numpy.any.html#numpy.any):
1) `numpy.any([1,2])` -> `True`
2) `numpy.any([0,1])` -> `True`
3) `numpy.any([])` -> `False`
4) `numpy.any([0,0])` -> `False`

I.e., it only evaluates to `False` if no element in the array evaluates to `True`.

So case 3 is likely the intention behind its usage, but case 4 is the unwanted side effect concerning black images input.

The new check keeps the security of blocking empty images but removes the unwanted side effect. Additionally, it increases safety by checking the number of image channels matching the format needed by the [model's input layer](https://github.com/serengil/retinaface/blob/e7aebd4ec9daac47f3e7e485e0567a8d79126125/retinaface/model/retinaface_model.py#L54). :slightly_smiling_face: