### PR TITLE
Also return original image face location when extracting faces

### DIFF
--- a/retinaface/RetinaFace.py
+++ b/retinaface/RetinaFace.py
@@ -181,7 +181,7 @@ def detect_faces(img_path, threshold=0.9, model = None, allow_upscaling = True):
 
     return resp
 
-def extract_faces(img_path, threshold=0.9, model = None, align = True, allow_upscaling = True):
+def extract_faces(img_path, threshold=0.9, model = None, align = True, allow_upscaling = True, return_location = False):
 
     resp = []
 
@@ -210,7 +210,10 @@ def extract_faces(img_path, threshold=0.9, model = None, align = True, allow_ups
 
                 facial_img = postprocess.alignment_procedure(facial_img, right_eye, left_eye, nose)
 
-            resp.append(facial_img[:, :, ::-1])
+            if return_location:
+                resp.append([facial_img[:, :, ::-1], facial_area])
+            else:
+                resp.append(facial_img[:, :, ::-1])
     #elif type(obj) == tuple:
 
     return resp


### PR DESCRIPTION
I wrote a few simple lines to retrieve the extracted faces' original image locations alongside the faces themselves, because when one detects a lot of faces from one image with RetinaFace and uses Deepface to verify all of these faces against some other face reference image, it is very useful to visualize where exactly the verified face was found in the original image. As far as I understand, this functionality in this specific use case was not possible before. 

Example semi-pseudo code:
```
filename = "path_to_image"
faces_and_locations = RetinaFace.extract_faces(filename, return_location = True)

image = Image.open(filename)

model = DeepFace.build_model("Facenet512")
for face, face_location in faces_and_locations:
    verification = DeepFace.verify(img1_path = face, img2_path = "path_to_ref_img", model = model, detector_backend="retinaface", enforce_detection=False)
    
    if verification["verified"] == True:
        draw_rectangle_in_image(image, face_location, "green", width = 5, deepface = False)
    else:
        draw_rectangle_in_image(image, face_location, "red", width = 5, deepface = False)
        
display(image)
```

So in this example, where I wanted to find David Hasselhoff, we get something like this:
![image](https://user-images.githubusercontent.com/44437600/174076853-7a4b49e3-7c7c-4373-8f60-9093c0e50b67.png)