### PR TITLE
Rotate image 180 degrees if both eyes below nose

### DIFF
--- a/retinaface/commons/postprocess.py
+++ b/retinaface/commons/postprocess.py
@@ -74,6 +74,10 @@ def alignment_procedure(img, left_eye, right_eye, nose):
         img = Image.fromarray(img)
         img = np.array(img.rotate(direction * angle))
 
+        if left_eye[1] > nose[1] and right_eye[1] > nose[1]:
+           img = Image.fromarray(img)
+           img = np.array(img.rotate(180))
+
     #-----------------------
 
     return img #return img anyway


### PR DESCRIPTION
I noticed that RetinaFace was able to locate landmarks for images that are upside down.

As such, I re-added the 180-degree rotation, but altered the conditional slightly: Instead of looking at `center_eyes`, check if both eyes are below the nose.

With this, images at angles 0, 90, 180, and 270 are being aligned properly.