### PR TITLE
align first by default

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+## Tickets
+
+https://github.com/serengil/retinaface/issues/XXX
+
+### What has been done
+
+With this PR, ...
+
+## How to test
+
+```shell
+make lint && make test
+```

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -75,7 +75,7 @@ def test_alignment_for_clock_way():
 
 
 def do_alignment_checks(img: np.ndarray, expected_faces: int) -> None:
-    faces = RetinaFace.extract_faces(img_path=img, align=True, expand_face_area=100)
+    faces = RetinaFace.extract_faces(img_path=img, align=True, expand_face_area=10)
 
     # it has one clear face
     assert len(faces) == expected_faces

--- a/tests/test_align_first.py
+++ b/tests/test_align_first.py
@@ -6,16 +6,7 @@ logger = Logger("tests/test_actions.py")
 
 THRESHOLD = 1000
 
-
-def test_detect_first():
-    """
-    Test the default behavior. Detect first and align second causes
-        so many black pixels
-    """
-    faces = RetinaFace.extract_faces(img_path="tests/dataset/img11.jpg")
-    num_black_pixels = np.sum(np.all(faces[0] == 0, axis=2))
-    assert num_black_pixels > THRESHOLD
-    logger.info("✅ Disabled align_first test for single face photo done")
+VISUAL_TEST = False
 
 
 def test_align_first():
@@ -23,7 +14,7 @@ def test_align_first():
     Test align first behavior. Align first and detect second do not cause
         so many black pixels in contrast to default behavior
     """
-    faces = RetinaFace.extract_faces(img_path="tests/dataset/img11.jpg", align_first=True)
+    faces = RetinaFace.extract_faces(img_path="tests/dataset/img11.jpg")
     num_black_pixels = np.sum(np.all(faces[0] == 0, axis=2))
     assert num_black_pixels < THRESHOLD
     logger.info("✅ Enabled align_first test for single face photo  done")
@@ -34,22 +25,14 @@ def test_align_first_for_group_photo():
     Align first will not work if the given image has many faces and
         it will cause so many black pixels
     """
-    faces = RetinaFace.extract_faces(img_path="tests/dataset/couple.jpg", align_first=True)
-    for face in faces:
-        num_black_pixels = np.sum(np.all(face == 0, axis=2))
-        assert num_black_pixels > THRESHOLD
-
-    logger.info("✅ Enabled align_first test for group photo done")
-
-
-def test_default_behavior_for_group_photo():
-    """
-    Align first will not work in the default behaviour and
-        it will cause so many black pixels
-    """
     faces = RetinaFace.extract_faces(img_path="tests/dataset/couple.jpg")
     for face in faces:
         num_black_pixels = np.sum(np.all(face == 0, axis=2))
-        assert num_black_pixels > THRESHOLD
+        assert num_black_pixels < THRESHOLD
+        if VISUAL_TEST is True:
+            import matplotlib.pyplot as plt
 
-    logger.info("✅ Disabled align_first test for group photo done")
+            plt.imshow(face)
+            plt.show()
+
+    logger.info("✅ Enabled align_first test for group photo done")


### PR DESCRIPTION
## Tickets

- https://github.com/serengil/retinaface/issues/84

## What has been done

- With this PR, we will perform align first by default. Besides, we will no longer check number of faces to align first. In that way, detected and aligned facial image will have less black pixels.

## How to test

```shell
make test && make lint
```